### PR TITLE
replace path with curve to fix deprecation warnings

### DIFF
--- a/src/shadow-path.typ
+++ b/src/shadow-path.typ
@@ -111,12 +111,16 @@
                 top + left,
                 dx: 50%,
                 dy: 50%,
-                path(
-                  closed: true,
+                curve(
                   fill: gradient.radial(..shadow-stops, center: (50%, 50%), radius: 50%, relative: "parent"),
-                  (d0, _mult(_rot(d0, -90deg), calc.sin(da / 2)), (0pt, 0pt)),
-                  (0pt, 0pt),
-                  ((d1), (0pt, 0pt), _mult(_rot(d1, 90deg), calc.sin(da / 2)),),
+                  curve.move((0pt, 0pt)),
+                  curve.line(d1),
+                  curve.cubic(
+                    _add(d1, _mult(_rot(d1, 90deg), calc.sin(da / 2))),
+                    _add(d0, _mult(_rot(d0, -90deg), calc.sin(da / 2))),
+                    d0,
+                  ),
+                  curve.close(mode: "straight"),
                 ),
               ),
             ),
@@ -125,7 +129,13 @@
       }
 
       if fill != none or stroke != none {
-        path(fill: fill, stroke: stroke, closed: closed, ..vertices)
+        curve(fill: fill, stroke: stroke,
+          curve.move(vertices.first()),
+          ..vertices.slice(1).map(curve.line),
+          ..if closed {
+            (curve.close(),)
+          },
+        )
       }
     },
   )


### PR DESCRIPTION
Fixes #1.

The main differences in the API are:

- `closed: true` is replaced by a `curve.close()` segment
- bezier anchors now use absolute coordinates, not relative to the vertex
- path was vertex-centric, while curve is edge-centric: with `path`, each vertex could specify the control points _around itself_, i.e. control points belonging to different curves. with `vertex`, a `curve.cubic` specifies the control poitns of that curve, i.e. control points relating to two different vertices
  - this also meant that, instead of going `d0` -> `origin` -> `d1` and letting the closing edge be the cubic bezier, I went with `origin` -> `d1` -> `d0` to make the cubic `d1` -> `d0` edge explicit

with that in mind I hope it's easy to verify that the new code is equivalent (and visual inspection of the `basic.typ` example confirmed that)